### PR TITLE
[stack 5/5] Bug fixes: credential UI + console-flash, single-instance, Deepgram max-speakers default, 6 CodeRabbit findings

### DIFF
--- a/docs/deep-work-log.md
+++ b/docs/deep-work-log.md
@@ -296,3 +296,39 @@ v0.4.0 rsac pin and a sysinfo-0.39 macOS/Linux process-picker smoke (the only
 per-OS surface in B36). The backlog of *locally-actionable* work is again at zero.
 
 
+
+## Run 2026-05-31 (later) — non-headless box unblocks: tests execute, B16 models, B21 done, release build
+
+Reframe after confirming the dev box is a real Windows+WSL workstation with green
+all-platform Blacksmith CI — several "gated" items were phantom gates.
+
+- **B23/2.7 SOLVED** — native Windows `cargo test` works via the in-repo
+  `AUDIOGRAPH_EMBED_WINDOWS_TEST_MANIFEST=1` (embeds `windows-app-manifest.xml`,
+  Common-Controls v6 SxS); CI's `rust-windows` already uses it. WSL Ubuntu is a
+  secondary path. Full suite now EXECUTES: cloud 449 / local-ml 450 / diar 58,
+  0 failed. (`docs/ops/windows-rust-test-crt-skew.md`, `scripts/run-rust-tests-wsl.sh`.)
+- **B16 model-validated** — real pyannote-seg-3.0 + TitaNet ONNX downloaded into
+  the app cache (`%APPDATA%\com.rsac.audiograph\models`, per `get_models_dir` +
+  the bzip2/tar `download_archive_model` convention); new env-gated test
+  `constructs_and_runs_against_real_models` proves `ClusteringDiarizer::new()`
+  loads them + `diarize()` runs the full ONNX pipeline (executed in WSL). Only
+  `num_speakers>4` accuracy remains (needs a labeled clip).
+- **B21 edition-2024 DONE** (`d3b190f`) — flipped + CI-green on all 3 OSes
+  (`rust-macos`/`-linux`/`-windows` Blacksmith). `cargo fix --edition` + `clippy
+  --fix` (nested-if→let_chains) resolved all 24 `tail_expr_drop_order` sites with
+  no hand-rewrites; tests-pass-under-2024 is the behavioral proof. `#![warn(...)]`
+  guard added. Verified locally Windows-native + WSL-Linux (clippy -D warnings +
+  test + fmt, all feature sets).
+- **Release build verified + artifacts produced** — `tauri build` under edition
+  2024, release profile [optimized], full local-ml: `audio-graph.exe` (83 MB) +
+  NSIS installer `AudioGraph_0.1.0-rc.1_x64-setup.exe` (19 MB). First time the
+  RELEASE profile (not just debug/test) was built post-edition-flip — green.
+- **Credentials**: `%APPDATA%\audio-graph\credentials.yaml` already exists with
+  the full schema + live `openrouter_api_key`/`deepgram_api_key`; only
+  `openai_api_key` (B15) + `gemini_api_key` (B18) slots are empty — fill those two
+  lines or use the release build's Express Setup for live runtime smoke.
+
+**Residual (all external-input-gated):** B15/B18 live runtime (2 API key values),
+B16 accuracy (labeled multi-speaker clip), B32 framework-majors (effort, not
+platform — CI covers it), B26 signing certs (procurement). Everything code +
+machine + models + CI is done and verified across Windows/Linux/macOS.

--- a/docs/reviews/deferred-ledger-2026-05-30.md
+++ b/docs/reviews/deferred-ledger-2026-05-30.md
@@ -36,10 +36,10 @@ model-less, audio-deviceless loop. The build+CI-verify-flag-runtime decision
 
 | Item | Built | Runtime gate (what's needed to validate) |
 |------|-------|------------------------------------------|
-| **B15** OpenAI Realtime STT | client + parser + reconnect + settings + dispatch; 8 verbatim-JSON parser tests | a live `OPENAI_API_KEY` + network — to validate the real WS handshake, transcript streaming, reconnect against a live socket |
+| **B15** OpenAI Realtime STT | client + parser + reconnect + settings + dispatch; 8 verbatim-JSON parser tests | a live **`openai_api_key`** — the credential store (`%APPDATA%\audio-graph\credentials.yaml`) already exists with the full schema (and live `openrouter_api_key` + `deepgram_api_key`); only the `openai_api_key` slot is empty. Fill that one line (or enter it via Express Setup in the release build), then live-smoke the WS handshake / transcript streaming / reconnect. |
 | **B16** diarization engine+worker+downloads | `LiveDiarizationWorker`, `SpeakerEmbeddingExtractor` stream, model downloaders, pure glue tests **+ model-load/pipeline VALIDATED 2026-05-31** (real pyannote-seg + TitaNet ONNX downloaded into the app cache; `ClusteringDiarizer::new()` loads them, `sample_rate()==16000`, `diarize()` runs the full ONNX pipeline — test `constructs_and_runs_against_real_models`, executed in WSL) | **Only `num_speakers > 4` ACCURACY remains** — needs a *curated/labeled* multi-speaker 16 kHz clip (a data-collection task, not code/env). Construction + inference are now proven on real models. Threshold tuning (`clustering.threshold`/`sim_threshold`) wants the same clip. |
 | **B16-pipe** worker→pipeline wiring | (Wave 3a) spawn + 16k tap + time-offset + SPEAKER_DETECTED — unit-tests executed green in WSL | accuracy only (same labeled-clip gate as B16) |
-| **B18** native S2S (Gemini AUDIO + turn FSM) | (Wave 3a) AUDIO config + event decode + pure FSM with gating | a live Gemini key + audio playback device — real barge-in, AEC, audio-out |
+| **B18** native S2S (Gemini AUDIO + turn FSM) | (Wave 3a) AUDIO config + event decode + pure FSM with gating | a live **`gemini_api_key`** (empty slot in the existing credentials.yaml — fill the one line or use Express Setup) + an audio playback device — real barge-in, AEC, audio-out |
 | **B33** B15 commit-cadence / Connected semantics | n/a (tuning) | a live key — to measure per-chunk-vs-per-utterance commit cost / 429 behavior |
 
 **Note (UPDATED 2026-05-31):** the Rust tests are no longer execution-gated. The

--- a/scripts/run-standalone.ps1
+++ b/scripts/run-standalone.ps1
@@ -1,0 +1,53 @@
+# Launch the standalone release build of AudioGraph (no installer needed).
+#
+# WHY: the standalone `audio-graph.exe` is the better dev-loop artifact than the
+# NSIS installer — it runs in place (no install/uninstall churn per rebuild) and
+# reads the SAME per-user state the installed app would:
+#   - settings: %APPDATA%\com.rsac.audiograph\settings.json
+#   - credentials: %APPDATA%\audio-graph\credentials.yaml   (your API keys)
+#   - models: %APPDATA%\com.rsac.audiograph\models
+#   - logs: %APPDATA%\audio-graph\logs\audio-graph.log
+# The only thing the installer additionally provisions is the WebView2 Evergreen
+# runtime, which Windows 11 already ships (verified present), so the standalone is
+# fully self-sufficient on this machine.
+#
+# Build it first if needed:
+#   bunx tauri build --no-bundle          # just the exe (fastest)
+#   bunx tauri build --bundles nsis       # exe + installer
+#
+# Usage (from the repo root, in PowerShell):
+#   ./scripts/run-standalone.ps1            # launch detached
+#   ./scripts/run-standalone.ps1 -Tail      # launch, then tail the log
+[CmdletBinding()]
+param(
+    # After launching, follow the live log (Ctrl+C to stop tailing; the app keeps running).
+    [switch]$Tail
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$exe = Join-Path $repoRoot 'src-tauri\target\release\audio-graph.exe'
+
+if (-not (Test-Path $exe)) {
+    Write-Error "Standalone build not found at $exe`nBuild it first: bunx tauri build --no-bundle"
+}
+
+# Start-Process fully detaches from this shell, so the app survives the script
+# exiting (unlike `cmd /c start` launched from a transient subshell).
+Write-Host "Launching $exe ..."
+Start-Process -FilePath $exe -WorkingDirectory (Split-Path -Parent $exe)
+Write-Host "Launched (detached). Window should appear shortly."
+
+$log = Join-Path $env:APPDATA 'audio-graph\logs\audio-graph.log'
+Write-Host "Log: $log"
+
+if ($Tail) {
+    Start-Sleep -Seconds 2
+    if (Test-Path $log) {
+        Write-Host "--- tailing log (Ctrl+C stops the tail; the app keeps running) ---"
+        Get-Content -Path $log -Tail 20 -Wait
+    }
+    else {
+        Write-Host "Log not created yet; check $log shortly."
+    }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,10 @@ llama-cpp-2 = { version = "0.1.139", optional = true, features = ["metal"] }
 [dependencies]
 # Tauri framework
 tauri = { version = "2.10.3", features = ["devtools"] }
+# Single-instance guard (BUG-3): a 2nd launch focuses the running window instead
+# of spawning a broken process that fails WebView2 creation (0x800700AA, shared
+# user-data-dir lock). Desktop-only; must be the FIRST plugin registered.
+tauri-plugin-single-instance = "2"
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -541,6 +541,40 @@ pub async fn stop_capture(
                 }
                 *client_guard = None;
             }
+            // Also TAKE + clear the Gemini worker-thread handles, then join them
+            // off-thread. Without this they stay `Some(..)` so the next
+            // `start_gemini` skips recreating the audio/event loops and comes back
+            // without a live Gemini event receiver (CodeRabbit commands.rs:543).
+            // We detach the join (no .await in this sync block) so Stop stays
+            // responsive; clearing the handles is the correctness-critical part.
+            let audio_h = state
+                .gemini_audio_thread
+                .lock()
+                .ok()
+                .and_then(|mut g| g.take());
+            let event_h = state
+                .gemini_event_thread
+                .lock()
+                .ok()
+                .and_then(|mut g| g.take());
+            if audio_h.is_some() || event_h.is_some() {
+                std::thread::spawn(move || {
+                    if let Some(h) = audio_h {
+                        join_worker_with_timeout(
+                            h,
+                            std::time::Duration::from_secs(3),
+                            "Gemini audio worker (capture stop)",
+                        );
+                    }
+                    if let Some(h) = event_h {
+                        join_worker_with_timeout(
+                            h,
+                            std::time::Duration::from_secs(3),
+                            "Gemini event worker (capture stop)",
+                        );
+                    }
+                });
+            }
         }
         if let Ok(mut status) = state.pipeline_status.write() {
             status.capture = StageStatus::Idle;
@@ -2515,10 +2549,10 @@ pub async fn start_gemini(state: State<'_, AppState>, app: tauri::AppHandle) -> 
                             // TurnMachine) consumes them via `gemini_event_to_signal`.
                             // We log + ignore here so the notes path stays
                             // exhaustive without taking on converse wiring.
-                            GeminiEvent::AudioChunk { ref data, .. } => {
+                            GeminiEvent::AudioChunk { ref data_base64, .. } => {
                                 log::debug!(
-                                    "Gemini: unexpected AudioChunk ({} bytes) on notes-mode path; ignoring",
-                                    data.len()
+                                    "Gemini: unexpected AudioChunk ({} b64 chars) on notes-mode path; ignoring",
+                                    data_base64.len()
                                 );
                             }
                             GeminiEvent::OutputTranscription { .. } => {

--- a/src-tauri/src/converse/mod.rs
+++ b/src-tauri/src/converse/mod.rs
@@ -456,8 +456,17 @@ impl Default for TurnMachine {
 /// barge-in trigger — gated client-side), `input_audio_buffer.speech_stopped
 /// → UserSpeechEnded`, `response.done → TurnComplete`. The FSM is unchanged.
 pub fn gemini_event_to_signal(event: GeminiEvent) -> Option<TurnSignal> {
+    use base64::Engine as _;
     match event {
-        GeminiEvent::AudioChunk { data, .. } => Some(TurnSignal::AssistantAudio { pcm24: data }),
+        // Decode the base64 audio at the point of use (the event carries it as a
+        // compact string to avoid JSON int-array bloat over IPC — see
+        // GeminiEvent::AudioChunk). Drop a chunk that won't decode rather than
+        // feeding garbage to playback.
+        GeminiEvent::AudioChunk { data_base64, .. } => base64::engine::general_purpose::STANDARD
+            .decode(&data_base64)
+            .ok()
+            .filter(|b| !b.is_empty())
+            .map(|pcm24| TurnSignal::AssistantAudio { pcm24 }),
         GeminiEvent::OutputTranscription { text } => Some(TurnSignal::AssistantTranscript {
             text,
             final_: false,
@@ -901,7 +910,7 @@ mod tests {
     #[test]
     fn gemini_audio_chunk_maps_to_assistant_audio() {
         let sig = gemini_event_to_signal(GeminiEvent::AudioChunk {
-            data: vec![1, 2, 3],
+            data_base64: "AQID".into(), // base64 of [1,2,3]
             sample_rate: 24_000,
         });
         assert_eq!(
@@ -910,6 +919,25 @@ mod tests {
                 pcm24: vec![1, 2, 3]
             })
         );
+    }
+
+    #[test]
+    fn gemini_invalid_base64_audio_maps_to_none() {
+        // Decode happens here (point of use); a chunk whose base64 won't decode
+        // is dropped (-> None) rather than feeding garbage to playback. This is
+        // the downstream half of the "dropped, not panicked" guarantee that used
+        // to live in handle_server_message before decode was deferred.
+        let sig = gemini_event_to_signal(GeminiEvent::AudioChunk {
+            data_base64: "!!!notb64!!!".into(),
+            sample_rate: 24_000,
+        });
+        assert_eq!(sig, None);
+        // An empty (but valid) payload also yields nothing to play.
+        let empty = gemini_event_to_signal(GeminiEvent::AudioChunk {
+            data_base64: String::new(),
+            sample_rate: 24_000,
+        });
+        assert_eq!(empty, None);
     }
 
     #[test]
@@ -1028,7 +1056,7 @@ mod tests {
 
         // First audio chunk from Gemini → Speaking.
         if let Some(sig) = gemini_event_to_signal(GeminiEvent::AudioChunk {
-            data: vec![0, 1],
+            data_base64: "AAE=".into(), // base64 of [0,1]
             sample_rate: 24_000,
         }) {
             m.on_signal(sig);

--- a/src-tauri/src/credentials/mod.rs
+++ b/src-tauri/src/credentials/mod.rs
@@ -1,4 +1,14 @@
-//! Credential management — stores API keys in ~/.config/audio-graph/credentials.yaml.
+//! Credential management — stores API keys in `<config_dir>/audio-graph/credentials.yaml`,
+//! where `<config_dir>` is `dirs::config_dir()`:
+//!   - Linux:   `~/.config/audio-graph/credentials.yaml`
+//!   - Windows: `%APPDATA%\audio-graph\credentials.yaml`  (e.g. `C:\Users\<you>\AppData\Roaming\audio-graph`)
+//!   - macOS:   `~/Library/Application Support/audio-graph/credentials.yaml`
+//!
+//! NOTE: this is the **credentials** store. It is intentionally a *different*
+//! directory from the Tauri app-data / model cache (`app_data_dir()` =
+//! `…/com.rsac.audiograph/`, by bundle id), so secrets and downloaded models
+//! don't share a tree. Secrets are zeroized in memory (`ZeroizeOnDrop`) and the
+//! file is locked owner-only on save (`fs_util::set_owner_only`).
 
 use serde::{Deserialize, Serialize};
 use std::fs;

--- a/src-tauri/src/diarization/worker.rs
+++ b/src-tauri/src/diarization/worker.rs
@@ -176,15 +176,15 @@ pub fn rolling_trim_count(buf_len: usize, window_samples: u64) -> usize {
     buf_len.saturating_sub(cap)
 }
 
-/// Absolute (worker-owned) sample index of a diarization window's first sample,
-/// given the cumulative samples ingested so far and this window's length (B16-offset).
-/// The rolling buffer's tail aligns with `total_ingested`, so the window begins
-/// `window_len` samples before it (saturating at 0 in the early-session case where
-/// `take < window_samples`). **Pure** — the stamp the consumer turns into exact
-/// session time (`window_start_sample / sample_rate + seg.start`), with no
-/// producer-side reconstruction (and so no backpressure / dropped-sample skew).
-pub fn window_start_sample(total_ingested: u64, window_len: usize) -> u64 {
-    total_ingested.saturating_sub(window_len as u64)
+/// Absolute session-time sample index of a diarization window's first sample,
+/// given `total_fed` (cumulative samples presented to the feed, including dropped
+/// ones) and this window's length (B16-offset). The window's last sample aligns
+/// with the latest fed position, so it begins `window_len` samples before it
+/// (saturating at 0 early in a session). Measuring from the fed clock — not the
+/// popped count — keeps the stamp aligned with the transcript timeline even when
+/// the ring drops audio (CodeRabbit worker.rs:260). **Pure.**
+pub fn window_start_sample(total_fed: u64, window_len: usize) -> u64 {
+    total_fed.saturating_sub(window_len as u64)
 }
 
 /// Default rolling-window length (s) of context handed to `diarize` each run.
@@ -213,7 +213,7 @@ mod imp {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-    use ringbuf::traits::{Consumer, Producer, Split};
+    use ringbuf::traits::{Consumer, Observer, Producer, Split};
     use ringbuf::{HeapCons, HeapProd, HeapRb};
     use sherpa_onnx::{SpeakerEmbeddingExtractor, SpeakerEmbeddingExtractorConfig};
 
@@ -225,13 +225,14 @@ mod imp {
     /// the cross-window registry. `UNKNOWN_SPEAKER` (`u32::MAX`) means the cluster
     /// embedding was degenerate/too-short to identify (see `stabilize`).
     ///
-    /// `window_start_sample` is the worker's **own** absolute ingested-sample
-    /// index of this window's first sample, stamped at diarize time (B16-offset).
-    /// The consumer recovers exact session time as
-    /// `(window_start_sample / sample_rate) + start` — this is precise even under
-    /// backpressure, unlike reconstructing the origin from the producer's
-    /// cumulative fed-sample count (which over-counts ring backlog + dropped
-    /// samples that were never diarized).
+    /// `window_start_sample` is the absolute session-time sample index of this
+    /// window's first sample, stamped at diarize time (B16-offset). It is measured
+    /// from the **fed** clock (every sample presented to the feed, including ones
+    /// the ring dropped under backpressure), so it stays aligned with the
+    /// transcript/ASR timeline even when audio is dropped — counting only the
+    /// samples the worker popped would compress those gaps out and shift later
+    /// spans earlier (CodeRabbit worker.rs:260). The consumer recovers session
+    /// time as `(window_start_sample / sample_rate) + start`.
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub struct StableSegment {
         pub start: f32,
@@ -245,6 +246,13 @@ mod imp {
     pub struct DiarizationFeed {
         prod: HeapProd<f32>,
         dropped: Arc<AtomicU64>,
+        /// Cumulative samples *presented to the feed* (accepted + dropped),
+        /// shared with the worker. This is the session-time clock: dropped
+        /// samples still represent elapsed audio (the transcript/ASR timeline
+        /// advances through them), so window timestamps must be measured in fed
+        /// samples — counting only popped samples shifts later spans earlier by
+        /// the dropped duration (CodeRabbit, worker.rs:260).
+        total_fed: Arc<AtomicU64>,
     }
 
     impl DiarizationFeed {
@@ -253,6 +261,10 @@ mod imp {
         /// shortfall is added to the dropped-sample counter and never blocks the
         /// audio thread.
         pub fn push(&mut self, samples: &[f32]) -> usize {
+            // Advance the session-time clock by EVERY sample presented, even ones
+            // the ring can't accept — they still occupy real audio time.
+            self.total_fed
+                .fetch_add(samples.len() as u64, Ordering::Relaxed);
             let wrote = self.prod.push_slice(samples);
             if wrote < samples.len() {
                 self.dropped
@@ -281,10 +293,11 @@ mod imp {
         rolling: Vec<f32>,
         sample_rate: u32,
         hop_secs: f32,
-        /// Worker-owned cumulative count of samples popped into the rolling
-        /// buffer. Used to stamp each emitted span's absolute window-start sample
-        /// index (B16-offset) so the consumer never has to reconstruct it.
-        total_ingested: u64,
+        /// Shared session-time clock: cumulative samples presented to the feed
+        /// (accepted + dropped). The window-start stamp is derived from this so
+        /// dropped audio doesn't compress the timeline and shift later spans
+        /// earlier than transcript time (CodeRabbit worker.rs:260).
+        total_fed: Arc<AtomicU64>,
     }
 
     impl LiveDiarizationWorker {
@@ -328,6 +341,7 @@ mod imp {
             let rb = HeapRb::<f32>::new(RING_CAPACITY_SAMPLES);
             let (prod, cons) = rb.split();
             let dropped = Arc::new(AtomicU64::new(0));
+            let total_fed = Arc::new(AtomicU64::new(0));
 
             let sr = sample_rate as u32;
             let schedule = WindowSchedule::new(sr, window_secs, hop_secs, min_start_secs);
@@ -342,9 +356,13 @@ mod imp {
                 rolling: Vec::with_capacity(schedule_window_capacity(sr, window_secs)),
                 sample_rate: sr,
                 hop_secs,
-                total_ingested: 0,
+                total_fed: total_fed.clone(),
             };
-            let feed = DiarizationFeed { prod, dropped };
+            let feed = DiarizationFeed {
+                prod,
+                dropped,
+                total_fed,
+            };
             Ok((worker, feed))
         }
 
@@ -375,7 +393,6 @@ mod imp {
                             got_any = true;
                             self.rolling.extend_from_slice(&scratch[..n]);
                             self.schedule.ingest(n as u64);
-                            self.total_ingested = self.total_ingested.saturating_add(n as u64);
                         }
 
                         // Run as many due windows as the schedule reports.
@@ -396,6 +413,17 @@ mod imp {
 
                         if stop.load(Ordering::Relaxed) {
                             // Final drain pass already happened above; exit.
+                            break;
+                        }
+                        // Producer dropped AND the ring is fully drained → the
+                        // capture side is gone for good; exit instead of sleeping
+                        // forever on an empty ring (CodeRabbit worker.rs:404).
+                        // `write_is_held()` is ringbuf's "a producer still exists"
+                        // signal; we only break once we've also consumed everything.
+                        if !self.cons.write_is_held() && self.cons.is_empty() {
+                            log::info!(
+                                "diarization-clustering: producer dropped + ring drained, exiting"
+                            );
                             break;
                         }
                         if !got_any {
@@ -431,10 +459,14 @@ mod imp {
             let window: &[f32] = &self.rolling[start..];
             let window_len = window.len();
             let window_secs = window_len as f32 / self.sample_rate as f32;
-            // Absolute (worker-owned) sample index of this window's first sample —
-            // exact even under backpressure (B16-offset); the consumer adds
-            // `seg.start` to this / sample_rate to get session time.
-            let window_start = window_start_sample(self.total_ingested, window_len);
+            // Absolute session-time sample index of this window's first sample.
+            // Measured from the FED clock (samples presented to the feed, incl.
+            // dropped) — not the popped count — so dropped audio doesn't compress
+            // the timeline and shift later spans earlier than transcript time
+            // (CodeRabbit worker.rs:260). The window's last sample aligns with the
+            // latest fed position; subtract the window length for its start.
+            let fed = self.total_fed.load(Ordering::Relaxed);
+            let window_start = window_start_sample(fed, window_len);
 
             let segments: Vec<ClusterSegment> = match self.diarizer.diarize(window) {
                 Ok(s) => s,

--- a/src-tauri/src/fs_util/mod.rs
+++ b/src-tauri/src/fs_util/mod.rs
@@ -27,11 +27,19 @@ pub fn set_owner_only(path: &Path) {
             );
             return;
         }
+        // CREATE_NO_WINDOW (0x08000000): icacls is a console app, so without this
+        // flag every credential/settings save flashes a console window on the
+        // user's screen (reported in the field). This is a silent background
+        // hardening step, so suppress the window. (User-facing "open folder"
+        // spawns in commands.rs deliberately do NOT set this — they should show.)
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         match std::process::Command::new("icacls")
             .arg(path)
             .arg("/inheritance:r")
             .arg("/grant:r")
             .arg(format!("{user}:F"))
+            .creation_flags(CREATE_NO_WINDOW)
             .output()
         {
             Ok(out) if out.status.success() => {}

--- a/src-tauri/src/gemini/mod.rs
+++ b/src-tauri/src/gemini/mod.rs
@@ -180,15 +180,25 @@ pub enum GeminiEvent {
     Reconnected { resumed: bool },
     /// A chunk of native model audio output (converse-mode, AUDIO modality).
     ///
-    /// Decoded from `serverContent.modelTurn.parts[].inlineData.data`
-    /// (base64) — raw 16-bit PCM, little-endian, mono. `sample_rate` is the
-    /// output rate, always **24000 Hz** for Gemini Live output audio
-    /// (research §1.3). Consumers feed `data` to the playback ring buffer.
+    /// Carries the **base64** payload from
+    /// `serverContent.modelTurn.parts[].inlineData.data` verbatim (raw 16-bit
+    /// PCM LE, mono, once decoded). `sample_rate` is the output rate, always
+    /// **24000 Hz** for Gemini Live output audio (research §1.3). Consumers
+    /// decode `data_base64` at the point of use (e.g. into the playback ring).
+    ///
+    /// We keep it as a base64 `String` rather than `Vec<u8>` because
+    /// `GeminiEvent` is `Serialize` and may cross the Tauri IPC boundary; a
+    /// `Vec<u8>` serializes to a JSON array of integers, which on a 24 kHz
+    /// realtime stream balloons payload size + parse cost on the hottest path
+    /// (CodeRabbit gemini/mod.rs:1469). A string stays compact.
     ///
     /// Only emitted when the session was set up with
     /// [`ResponseModality::Audio`]; notes-mode (TEXT) never produces this.
     #[serde(rename = "audio_chunk")]
-    AudioChunk { data: Vec<u8>, sample_rate: u32 },
+    AudioChunk {
+        data_base64: String,
+        sample_rate: u32,
+    },
     /// The server interrupted (barge-in): VAD detected user speech and the
     /// server canceled + discarded the in-flight generation
     /// (`serverContent.interrupted == true`, research §1.4). The client must
@@ -1466,23 +1476,17 @@ fn handle_server_message(
                     });
                 }
                 // AUDIO mode (research §1.3): native speech arrives as
-                // base64 PCM16 LE @ 24 kHz in `inlineData.data`. Decode and
-                // surface as an AudioChunk for the playback ring buffer.
+                // base64 PCM16 LE @ 24 kHz in `inlineData.data`. Forward the
+                // base64 string verbatim (the consumer decodes at the point of
+                // use) — see the AudioChunk doc for why we don't carry Vec<u8>.
                 if let Some(inline) = part.get("inlineData")
                     && let Some(b64) = inline.get("data").and_then(|d| d.as_str())
+                    && !b64.is_empty()
                 {
-                    match base64::engine::general_purpose::STANDARD.decode(b64) {
-                        Ok(bytes) if !bytes.is_empty() => {
-                            let _ = tx.send(GeminiEvent::AudioChunk {
-                                data: bytes,
-                                sample_rate: GEMINI_OUTPUT_SAMPLE_RATE,
-                            });
-                        }
-                        Ok(_) => {} // empty payload — ignore
-                        Err(e) => {
-                            log::warn!("Gemini Live: failed to base64-decode audio chunk: {e}");
-                        }
-                    }
+                    let _ = tx.send(GeminiEvent::AudioChunk {
+                        data_base64: b64.to_string(),
+                        sample_rate: GEMINI_OUTPUT_SAMPLE_RATE,
+                    });
                 }
             }
         }
@@ -1834,7 +1838,7 @@ mod tests {
             GeminiEvent::Reconnected { resumed: true },
             GeminiEvent::Reconnected { resumed: false },
             GeminiEvent::AudioChunk {
-                data: vec![0x00, 0x01, 0xff, 0x7f],
+                data_base64: "AAH/fw==".into(), // base64 of [0x00,0x01,0xff,0x7f]
                 sample_rate: GEMINI_OUTPUT_SAMPLE_RATE,
             },
             GeminiEvent::Interrupted,
@@ -2103,8 +2107,12 @@ mod tests {
         handle_server_message(msg, &tx, &handle);
 
         match rx.try_recv().unwrap() {
-            GeminiEvent::AudioChunk { data, sample_rate } => {
-                assert_eq!(data, vec![0x00, 0x01, 0x02, 0x03]);
+            GeminiEvent::AudioChunk {
+                data_base64,
+                sample_rate,
+            } => {
+                // Forwarded verbatim from inlineData.data (decoded at point of use).
+                assert_eq!(data_base64, "AAECAw==");
                 assert_eq!(sample_rate, GEMINI_OUTPUT_SAMPLE_RATE);
                 assert_eq!(sample_rate, 24_000);
             }
@@ -2139,8 +2147,8 @@ mod tests {
                     assert_eq!(text, "hi");
                     saw_text = true;
                 }
-                GeminiEvent::AudioChunk { data, .. } => {
-                    assert_eq!(data, vec![0x00, 0x01, 0x02, 0x03]);
+                GeminiEvent::AudioChunk { data_base64, .. } => {
+                    assert_eq!(data_base64, "AAECAw==");
                     saw_audio = true;
                 }
                 other => panic!("unexpected event {other:?}"),
@@ -2150,7 +2158,12 @@ mod tests {
     }
 
     #[test]
-    fn handle_server_invalid_base64_audio_is_dropped_not_panicked() {
+    fn handle_server_audio_forwards_base64_verbatim_without_decoding() {
+        // The handler no longer decodes (decode is deferred to the consumer, see
+        // GeminiEvent::AudioChunk). It must forward the inlineData string verbatim
+        // and never panic — including on a string that won't base64-decode; the
+        // decode-and-drop happens downstream in `gemini_event_to_signal` (see
+        // `gemini_invalid_base64_audio_maps_to_none` in the converse module).
         let (tx, rx) = crossbeam_channel::bounded(16);
         let handle = Arc::new(std::sync::Mutex::new(None));
 
@@ -2161,7 +2174,13 @@ mod tests {
         }"#;
         handle_server_message(msg, &tx, &handle);
 
-        // No event emitted for an undecodable chunk; handler must not panic.
+        match rx.try_recv().unwrap() {
+            GeminiEvent::AudioChunk { data_base64, .. } => {
+                assert_eq!(data_base64, "!!!notb64!!!");
+            }
+            other => panic!("Expected AudioChunk (verbatim), got {other:?}"),
+        }
+        // Only that one chunk; an empty inlineData string is the sole skip case.
         assert!(rx.try_recv().is_err());
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -124,6 +124,19 @@ pub fn run() {
     let session_id_handle = app_state.session_id.clone();
 
     tauri::Builder::default()
+        // BUG-3: single-instance guard MUST be the first plugin registered
+        // (plugins run in registration order). A second launch hands its argv
+        // here instead of spawning a process that fails WebView2 creation with
+        // 0x800700AA (the running instance holds the user-data-dir lock); we
+        // unminimize + focus the existing window so a re-launch behaves like
+        // "bring to front" rather than silently dying.
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.unminimize();
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }))
         .manage(app_state)
         .setup(|app| {
             // Load the persisted log-level preference as soon as we have an

--- a/src-tauri/src/llm/api_client.rs
+++ b/src-tauri/src/llm/api_client.rs
@@ -181,7 +181,10 @@ impl ApiClient {
 
         let mut req = self.client.post(&url).json(&request);
 
-        if let Some(ref key) = self.config.api_key
+        // Trim before deciding: a whitespace-only key ("   ") is effectively
+        // unset, and sending it as a bearer token turns "no key" into a hard auth
+        // failure (CodeRabbit api_client.rs:187).
+        if let Some(key) = self.config.api_key.as_deref().map(str::trim)
             && !key.is_empty()
         {
             req = req.header("Authorization", format!("Bearer {}", key));

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -55,8 +55,12 @@ fn default_deepgram_eot_timeout_ms() -> u32 {
     0
 }
 fn default_max_speakers() -> u32 {
-    // Default to 2 — the common 1:1 / interview case. `0` disables the cap.
-    2
+    // Default to 0 = NO cap: surface as many speakers as Deepgram actually
+    // detects. Speaker attribution is a headline feature, so the safe default is
+    // not to suppress it — capping to 2 by default silently hid real speakers
+    // (BUG-4: "stuck on 2 speakers"). Users who know they have a 1:1 / interview
+    // can opt INTO a small cap to tame Deepgram's occasional over-segmentation.
+    0
 }
 fn default_true() -> bool {
     true

--- a/src-tauri/src/speech/mod.rs
+++ b/src-tauri/src/speech/mod.rs
@@ -3198,6 +3198,19 @@ pub(crate) fn run_openai_realtime_speech_processor(
                     );
                     break;
                 }
+                // Idle: speech stopped before COMMIT_INTERVAL elapsed. Flush the
+                // buffered audio so a short utterance finalizes promptly instead
+                // of waiting for the next chunk or teardown (CodeRabbit
+                // speech/mod.rs:3240). The cadence commit only ran after
+                // send_audio(), so without this the tail can sit uncommitted.
+                if uncommitted_since_last && last_commit.elapsed() >= COMMIT_INTERVAL {
+                    if let Err(e) = client.commit() {
+                        log::warn!("OpenAI Realtime streaming: idle commit failed: {e}");
+                        break;
+                    }
+                    last_commit = std::time::Instant::now();
+                    uncommitted_since_last = false;
+                }
                 continue;
             }
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -88,6 +88,25 @@ describe("settingsReducer", () => {
     expect(next.logLevel).toBe("trace");
   });
 
+  it("HYDRATE_FROM_SETTINGS preserves a typed API key it does not patch (BUG-2 regression)", () => {
+    // The IPC `settings` object is always redacted (skip_serializing), so the
+    // settings-hydration path must NOT include `geminiApiKey` in its patch — the
+    // credential store is the sole source for it. A patch that omits the field
+    // must leave a user-typed value intact; if hydration ever re-seeds it from
+    // the redacted settings (`geminiApiKey: ""`), the field blanks after Save.
+    const typed: SettingsState = {
+      ...initialSettingsState,
+      geminiApiKey: "AIza-user-typed-key",
+    };
+    const next = settingsReducer(typed, {
+      type: "HYDRATE_FROM_SETTINGS",
+      // Mirrors the post-fix hydration patch: model + auth mode, but NO api key.
+      patch: { geminiModel: "gemini-2.0-flash-live-001", geminiAuthMode: "api_key" },
+    });
+    expect(next.geminiApiKey).toBe("AIza-user-typed-key");
+    expect(next.geminiModel).toBe("gemini-2.0-flash-live-001");
+  });
+
   it("SET_AWS_SHARED_SECRET mirrors the secret into both ASR and Bedrock slots", () => {
     const next = settingsReducer(initialSettingsState, {
       type: "SET_AWS_SHARED_SECRET",

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -674,13 +674,22 @@ function SettingsPage() {
       patch.geminiModel = settings.gemini.model;
       const auth = settings.gemini.auth;
       patch.geminiAuthMode = auth.type;
-      if (auth.type === "api_key") {
-        patch.geminiApiKey = auth.api_key ?? "";
-      } else if (auth.type === "vertex_ai") {
+      if (auth.type === "vertex_ai") {
         patch.geminiProjectId = auth.project_id;
         patch.geminiLocation = auth.location;
         patch.geminiServiceAccountPath = auth.service_account_path ?? "";
       }
+      // NOTE: we deliberately do NOT seed `geminiApiKey` from `auth.api_key`.
+      // The IPC `settings` object is ALWAYS redacted (`skip_serializing` +
+      // `redacted_settings`), so `auth.api_key` is the empty string here — and
+      // because HYDRATE_FROM_SETTINGS overwrites (`{...state, ...patch}`),
+      // including it would blank the field the user just saved (BUG-2: the key
+      // is safely stored, but the form went empty after Save). The credential
+      // store is the single source of truth for this field; it is loaded
+      // asynchronously below (`loadCredentialSnapshot` → `credentialPatch
+      // .geminiApiKey`) and otherwise only changes via the user typing
+      // (SET_FIELD). Same rationale as the ASR/LLM `api_key` fields, which are
+      // likewise populated from credentials, never from the redacted settings.
     }
 
     // TTS hydration — local state, not reducer.

--- a/src/components/settingsTypes.ts
+++ b/src/components/settingsTypes.ts
@@ -250,7 +250,9 @@ export const initialSettingsState: SettingsState = {
   deepgramEotThreshold: 0.5,
   deepgramEagerEotThreshold: 0,
   deepgramEotTimeoutMs: 0,
-  deepgramMaxSpeakers: 2,
+  // 0 = no cap: detect all speakers Deepgram reports (BUG-4 — must match the
+  // backend default_max_speakers()). A small cap is an opt-in for 1:1/interview.
+  deepgramMaxSpeakers: 0,
   assemblyaiApiKey: "",
   assemblyaiDiarization: true,
   sherpaModelDir: "streaming-zipformer-en-20M",


### PR DESCRIPTION
**Stacked PR 5 of 5** — base `stack-4-validation-edition` (PR #18). Diff = this layer's 6 commits.

Field-reported + review-surfaced fixes: API-key field no longer blanks on save + icacls console-flash silenced (BUG-1/2), single-instance guard (BUG-3), Deepgram max_speakers default 2→0 so speaker detection isn't silently capped (BUG-4), the standalone run script, and the 6 real CodeRabbit code findings (diarization fed-clock timeline, worker exit-on-drop, OpenAI idle-flush, Gemini handle-leak, AudioChunk base64-over-IPC, whitespace-key trim).

Stack: 1/5 → 2/5 → 3/5 → 4/5 → **5/5**. Closes the work formerly in #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)